### PR TITLE
Add error ssl

### DIFF
--- a/lib/apnserver/server.rb
+++ b/lib/apnserver/server.rb
@@ -25,7 +25,7 @@ module ApnServer
                 begin
                   @client.connect! unless @client.connected?
                   @client.write(notification)
-                rescue Errno::EPIPE, OpenSSL::SSL::SSLError
+                rescue Errno::EPIPE, OpenSSL::SSL::SSLError, Errno::ECONNRESET
                   puts "Caught Error, closing connecting and adding notification back to queue"
                   @client.disconnect!
                   @queue.push(notification)


### PR DESCRIPTION
Add Errno::ECONNRESET for prevent of /usr/lib/ruby/1.8/openssl/buffering.rb:178:in `syswrite': Connection reset by peer (Errno::ECONNRESET)
        from /usr/lib/ruby/1.8/openssl/buffering.rb:178:in`do_write'
        from /usr/lib/ruby/1.8/openssl/buffering.rb:192:in `write'
